### PR TITLE
Update ELCCpv1.py

### DIFF
--- a/ELCCpv1.py
+++ b/ELCCpv1.py
@@ -8,9 +8,10 @@ __version__ = "1.2"
 """This is the TXID standard. 
 Comment Component cert in JSON: 
 {
-  "module": "manufacturer modelcode",
+   "module": "manufacturer modelcode",
   "inverter": "maufacturer modelcode", 
   "data-logger": "maufacturer modelcode",
+  "data-logger-ECDHE-Pub": "Public key Hardware generated ID birth certificate", 
   "pyranometer": "manufacturer modelcode",
   "windsensor": "manufacturer modelcode",
   "rainsensor": "manufacturer modelcode",


### PR DESCRIPTION
We are requesting to add an entry to the Tx Message space so that a hardware generated ECDHE public key can be added. These Keys are made by Elliptic curve cryptography hardware chips installed at the birth of a data-logger in a secure environment. For example with the Chainofthings device identity protocol.

[(https://www.chainofthings.com/)]